### PR TITLE
events.on_command_error rewrite

### DIFF
--- a/Life/cogs/events.py
+++ b/Life/cogs/events.py
@@ -72,7 +72,6 @@ class Events(commands.Cog):
         ctx = await self.bot.get_context(message)
 
         if message.guild is None:
-
             time = self.bot.utils.format_datetime(datetime=pendulum.now(tz='UTC'))
             info = f'`Channel:` {ctx.channel} `{ctx.channel.id}`\n`Author:` {ctx.author} `{ctx.author.id}`\n`Time:` {time}'
 
@@ -82,7 +81,6 @@ class Events(commands.Cog):
                                                      avatar_url=str(ctx.author.avatar_url_as(format='gif' if ctx.author.is_avatar_animated() else 'png')))
 
         if self.bot.user in message.mentions:
-
             time = self.bot.utils.format_datetime(datetime=pendulum.now(tz='UTC'))
             info = f'`Guild:` {ctx.guild} `{ctx.guild.id}`\n`Channel:` {ctx.channel} `{ctx.channel.id}`\n`Author:` {ctx.author} `{ctx.author.id}`\n`Time:` {time}'
 
@@ -193,25 +191,25 @@ class Events(commands.Cog):
             return await ctx.send(message)
 
         error_messages = {
-            exceptions.ArgumentError: f'{error}',
-            exceptions.GeneralError: f'{error}',
-            exceptions.ImageError: f'{error}',
-            exceptions.VoiceError: f'{error}',
-            NodeNotFound: f'There are no lavalink nodes available right now.',
+            exceptions.ArgumentError:               f'{error}',
+            exceptions.GeneralError:                f'{error}',
+            exceptions.ImageError:                  f'{error}',
+            exceptions.VoiceError:                  f'{error}',
+            NodeNotFound:                           f'There are no lavalink nodes available right now.',
 
-            commands.TooManyArguments: f'You used too many arguments. Use `{self.bot.config.prefix}help {ctx.command}` for more information on what arguments to use.',
+            commands.TooManyArguments:              f'You used too many arguments. Use `{self.bot.config.prefix}help {ctx.command}` for more information on what arguments to use.',
 
-            commands.UnexpectedQuoteError: f'There was an unexpected quote character in the arguments you passed.',
+            commands.UnexpectedQuoteError:          f'There was an unexpected quote character in the arguments you passed.',
             commands.InvalidEndOfQuotedStringError: f'There was an unexpected space after a quote character in the arguments you passed.',
-            commands.ExpectedClosingQuoteError: f'There is a missing quote character in the arguments you passed.',
+            commands.ExpectedClosingQuoteError:     f'There is a missing quote character in the arguments you passed.',
 
-            commands.CheckFailure: f'{error}',
-            commands.PrivateMessageOnly: f'The command `{ctx.command}` can only be used in private messages',
-            commands.NoPrivateMessage: f'The command `{ctx.command}` can not be used in private messages.',
-            commands.NotOwner: f'The command `{ctx.command}` is owner only.',
-            commands.NSFWChannelRequired: f'The command `{ctx.command}` can only be run in a NSFW channel.',
+            commands.CheckFailure:                  f'{error}',
+            commands.PrivateMessageOnly:            f'The command `{ctx.command}` can only be used in private messages',
+            commands.NoPrivateMessage:              f'The command `{ctx.command}` can not be used in private messages.',
+            commands.NotOwner:                      f'The command `{ctx.command}` is owner only.',
+            commands.NSFWChannelRequired:           f'The command `{ctx.command}` can only be run in a NSFW channel.',
 
-            commands.DisabledCommand: f'The command `{ctx.command}` has been disabled.',
+            commands.DisabledCommand:               f'The command `{ctx.command}` has been disabled.',
         }
 
         message = error_messages.get(type(error), None)

--- a/Life/cogs/events.py
+++ b/Life/cogs/events.py
@@ -9,7 +9,9 @@
 #
 #  You should have received a copy of the GNU Affero General Public License along with Life. If not, see https://www.gnu.org/licenses/.
 #
+
 import logging
+import typing
 
 import discord
 import mystbin
@@ -101,7 +103,7 @@ class Events(commands.Cog):
         await self.bot.process_commands(after)
 
     @commands.Cog.listener()
-    async def on_command_error(self, ctx: context.Context, error) -> None:
+    async def on_command_error(self, ctx: context.Context, error) -> typing.Optional[discord.Message]:
 
         error = getattr(error, 'original', error)
 
@@ -111,102 +113,84 @@ class Events(commands.Cog):
         if isinstance(error, commands.CommandNotFound):
             return
 
-        elif isinstance(error, commands.CommandOnCooldown):
-            cooldown_types = {
-                commands.BucketType.default: f'for the whole bot.',
-                commands.BucketType.user: f'for you.',
-                commands.BucketType.member: f'for you.',
-                commands.BucketType.role: f'for your role.',
-                commands.BucketType.guild: f'for this server.',
-                commands.BucketType.channel: f'for this channel.',
-                commands.BucketType.category: f'for this channel category.'
-            }
-            await ctx.send(f'The command `{ctx.command}` is on cooldown {cooldown_types.get(error.cooldown.type, "for you.")} You can retry in '
-                           f'`{self.bot.utils.format_seconds(seconds=error.retry_after, friendly=True)}`')
-            return
-
-        elif isinstance(error, commands.MaxConcurrencyReached):
-            cooldowns = {
-                commands.BucketType.default: f'.',
-                commands.BucketType.user: f' per user.',
-                commands.BucketType.member: f' per member.',
-                commands.BucketType.role: f' per role.',
-                commands.BucketType.guild: f' per server.',
-                commands.BucketType.channel: f' per channel.',
-                commands.BucketType.category: f' per channel category.',
-            }
-            await ctx.send(f'The command `{ctx.command}` is being ran at its maximum of {error.number} time(s){cooldowns.get(error.per, ".")} Retry a bit later.')
-            return
-
-        elif isinstance(error, commands.BotMissingPermissions):
+        if isinstance(error, commands.BotMissingPermissions):
             permissions = '\n'.join([f'> {permission}' for permission in error.missing_perms])
             message = f'I am missing the following permissions required to run the command `{ctx.command}`.\n{permissions}'
-            try:
-                await ctx.send(message)
-            except discord.Forbidden:
-                try:
-                    await ctx.author.send(message)
-                except discord.Forbidden:
-                    return
-            return
+            return await ctx.try_dm(content=message)
+
+        message = None
+
+        if isinstance(error, commands.BadArgument):
+
+            argument = getattr(error, "argument", "None")
+            bad_argument_errors = {
+                commands.MessageNotFound:               f'A message for the argument `{argument}` was not found.',
+                commands.MemberNotFound:                f'A member for the argument `{argument}` was not found.',
+                commands.UserNotFound:                  f'A user for the argument `{argument}` was not found.',
+                commands.ChannelNotFound:               f'A channel for the argument `{argument}` was not found.',
+                commands.RoleNotFound:                  f'A role for the argument `{argument}` was not found.',
+                commands.EmojiNotFound:                 f'An emoji for the argument `{argument}` was not found.',
+                commands.ChannelNotReadable:            f'I do not have permission to read the channel `{argument}`',
+                commands.BadInviteArgument:             f'The invite `{argument}` was not valid or is expired.',
+                commands.PartialEmojiConversionFailure: f'The argument `{argument}` did not match the partial emoji format.',
+                commands.BadBoolArgument:               f'The argument `{argument}` was not a valid True or False value.',
+                commands.BadColourArgument:             f'The argument `{argument}` was not a valid colour type.',
+                BadLiteralArgument:                     f'The argument `{argument}` must be one of '
+                                                        f'{", ".join([f"`{valid_argument}`" for valid_argument in getattr(error, "valid_arguments", [])])}.',
+                commands.BadArgument:                   f'I was unable to convert an argument that you used. Use `{self.bot.config.prefix}help {ctx.command}` for more '
+                                                        f'information on what arguments to use.',
+            }
+            message = bad_argument_errors.get(type(error), 'None')
+
+        elif isinstance(error, commands.CommandOnCooldown):
+            cooldown_buckets = {
+                commands.BucketType.default:  f'for the whole bot.',
+                commands.BucketType.user:     f'for you.',
+                commands.BucketType.member:   f'for you.',
+                commands.BucketType.role:     f'for your role.',
+                commands.BucketType.guild:    f'for this server.',
+                commands.BucketType.channel:  f'for this channel.',
+                commands.BucketType.category: f'for this channel category.'
+            }
+            message = f'The command `{ctx.command}` is on cooldown {cooldown_buckets.get(error.cooldown.type, "for you.")} You can retry in ' \
+                      f'`{self.bot.utils.format_seconds(seconds=error.retry_after, friendly=True)}`'
+
+        elif isinstance(error, commands.MaxConcurrencyReached):
+            cooldown_types = {
+                commands.BucketType.default:  f'.',
+                commands.BucketType.user:     f' per user.',
+                commands.BucketType.member:   f' per member.',
+                commands.BucketType.role:     f' per role.',
+                commands.BucketType.guild:    f' per server.',
+                commands.BucketType.channel:  f' per channel.',
+                commands.BucketType.category: f' per channel category.',
+            }
+            message = f'The command `{ctx.command}` is being ran at its maximum of {error.number} time(s){cooldown_types.get(error.per, ".")} Retry a bit later.'
 
         elif isinstance(error, commands.MissingPermissions):
             permissions = '\n'.join([f'> {permission}' for permission in error.missing_perms])
-            await ctx.send(f'You are missing the following permissions required to run the command `{ctx.command}`.\n{permissions}')
-            return
+            message = f'You are missing the following permissions required to run the command `{ctx.command}`.\n{permissions}'
 
         elif isinstance(error, commands.MissingRequiredArgument):
-            await ctx.send(f'You missed the `{error.param.name}` argument. Use `{self.bot.config.prefix}help {ctx.command}` for more information on what arguments to use.')
-            return
+            message = f'You missed the `{error.param.name}` argument. Use `{self.bot.config.prefix}help {ctx.command}` for more information on what arguments to use.'
 
         elif isinstance(error, commands.BadUnionArgument):
-            await ctx.send(f'I was unable to convert the `{error.param}` argument. Use `{self.bot.config.prefix}help {ctx.command}` for more information on what arguments '
-                           f'to use.')
-            return
+            message = f'I was unable to convert the `{error.param.name}` argument. Use `{self.bot.config.prefix}help {ctx.command}` for more information on what arguments to use.'
 
         elif isinstance(error, commands.MissingRole):
-            await ctx.send(f'The role `{error.missing_role}` is required to run this command.')
-            return
+            message = f'The role `{error.missing_role}` is required to run this command.'
 
         elif isinstance(error, commands.BotMissingRole):
-            await ctx.send(f'The bot requires the role `{error.missing_role}` to run this command.')
-            return
+            message = f'The bot requires the role `{error.missing_role}` to run this command.'
 
         elif isinstance(error, commands.MissingAnyRole):
-            await ctx.send(f'The roles {", ".join([f"`{role}`" for role in error.missing_roles])} are required to run this command.')
-            return
+            message = f'The roles {", ".join([f"`{role}`" for role in error.missing_roles])} are required to run this command.'
 
         elif isinstance(error, commands.BotMissingAnyRole):
-            await ctx.send(f'The bot requires the roles {", ".join([f"`{role}`" for role in error.missing_roles])} to run this command.')
-            return
+            message = f'The bot requires the roles {", ".join([f"`{role}`" for role in error.missing_roles])} to run this command.'
 
-        elif isinstance(error, commands.BadArgument):
-
-            if isinstance(error, commands.MessageNotFound):
-                await ctx.send(f'A message for the argument `{error.argument}` was not found.')
-            elif isinstance(error, commands.MemberNotFound):
-                await ctx.send(f'A member for the argument `{error.argument}` was not found.')
-            elif isinstance(error, commands.UserNotFound):
-                await ctx.send(f'A user for the argument `{error.argument}` was not found.')
-            elif isinstance(error, commands.ChannelNotFound):
-                await ctx.send(f'A channel for the argument `{error.argument}` was not found.')
-            elif isinstance(error, commands.RoleNotFound):
-                await ctx.send(f'A role for the argument `{error.argument}` was not found.')
-            elif isinstance(error, commands.EmojiNotFound):
-                await ctx.send(f'An emoji for the argument `{error.argument}` was not found.')
-            elif isinstance(error, commands.ChannelNotReadable):
-                await ctx.send(f'I do not have permission to read the channel `{error.argument}`')
-            elif isinstance(error, commands.PartialEmojiConversionFailure):
-                await ctx.send(f'The argument `{error.argument}` did not match the partial emoji format.')
-            elif isinstance(error, commands.BadInviteArgument):
-                await ctx.send(f'The invite that matched that argument was not valid or is expired.')
-            elif isinstance(error, commands.BadBoolArgument):
-                await ctx.send(f'The argument `{error.argument}` was not a valid True/False value.')
-            elif isinstance(error, commands.BadColourArgument):
-                await ctx.send(f'The argument `{error.argument}` was not a valid colour.')
-            elif isinstance(error, BadLiteralArgument):
-                await ctx.send(f'The argument `{error.param.name}` must be one of {", ".join([f"`{arg}`" for arg in error.valid_arguments])}.')
-            return
+        if message:
+            return await ctx.send(message)
 
         error_messages = {
             exceptions.ArgumentError: f'{error}',
@@ -221,9 +205,6 @@ class Events(commands.Cog):
             commands.InvalidEndOfQuotedStringError: f'There was an unexpected space after a quote character in the arguments you passed.',
             commands.ExpectedClosingQuoteError: f'There is a missing quote character in the arguments you passed.',
 
-            commands.BadArgument: f'I was unable to convert an argument that you used. Use `{self.bot.config.prefix}help {ctx.command}` for more information on what '
-                                  f'arguments to use.',
-
             commands.CheckFailure: f'{error}',
             commands.PrivateMessageOnly: f'The command `{ctx.command}` can only be used in private messages',
             commands.NoPrivateMessage: f'The command `{ctx.command}` can not be used in private messages.',
@@ -233,25 +214,45 @@ class Events(commands.Cog):
             commands.DisabledCommand: f'The command `{ctx.command}` has been disabled.',
         }
 
-        error_message = error_messages.get(type(error), None)
-        if error_message is not None:
-            await ctx.send(error_message)
-            return
+        message = error_messages.get(type(error), None)
+        if message:
+            return await ctx.send(message)
+
+        await self.handle_traceback(ctx=ctx, error=error)
+
+    @commands.Cog.listener()
+    async def on_command(self, ctx: commands.Context) -> None:
+        log.info(f'[COMMANDS] Command used. Name: {ctx.command} | Invoker: {ctx.author} | Channel: {ctx.channel} ({ctx.channel.id}) | '
+                 f'{f"Guild: {ctx.guild} ({ctx.guild.id})" if ctx.guild else ""}')
+
+    @commands.Cog.listener()
+    async def on_socket_response(self, message: dict) -> None:
+
+        event = message.get('t', 'None')
+        if event is not None:
+            self.bot.socket_stats[event] += 1
+
+    #
+
+    async def handle_traceback(self, *, ctx: context.Context, error) -> None:
 
         await ctx.send(f'Something went wrong while executing that command. Please use `{self.bot.config.prefix}support` for more help or information.')
 
         self.bot.error_formatter.theme['_ansi_enabled'] = True
         print(f'\n{"".join(self.bot.error_formatter.format_exception(type(error), error, error.__traceback__)).strip()}\n')
 
-        time = self.bot.utils.format_datetime(datetime=pendulum.now(tz='UTC'))
-        guild = f'`Guild:` {ctx.guild} `{ctx.guild.id}`\n' if ctx.guild else ''
-        info = f'Error in command `{ctx.command}`\n\n{guild}`Channel:` {ctx.channel} `{ctx.channel.id}`\n`Author:` {ctx.author} `{ctx.author.id}`\n`Time:` {time}'
+        avatar_url = str(ctx.author.avatar_url_as(format='gif' if ctx.author.is_avatar_animated() else 'png'))
+
+        info = f'Error in command `{ctx.command}`\n\n' \
+               f'{f"`Guild:` {ctx.guild} `{ctx.guild.id}`" if ctx.guild else ""}\n' \
+               f'`Channel:` {ctx.channel} `{ctx.channel.id}`\n' \
+               f'`Author:` {ctx.author} `{ctx.author.id}`\n' \
+               f'`Time:` {self.bot.utils.format_datetime(datetime=pendulum.now(tz="UTC"))}'
 
         embed = discord.Embed(colour=ctx.colour, description=f'{ctx.message.content}')
         embed.add_field(name='Info:', value=info)
 
-        await self.bot.errors_webhook.send(embed=embed, username=f'{ctx.author}',
-                                           avatar_url=str(ctx.author.avatar_url_as(format='gif' if ctx.author.is_avatar_animated() else 'png')))
+        await self.bot.errors_webhook.send(embed=embed, username=f'{ctx.author}', avatar_url=avatar_url)
 
         self.bot.error_formatter.theme['_ansi_enabled'] = False
         traceback = "".join(self.bot.error_formatter.format_exception(type(error), error, error.__traceback__)).strip()
@@ -265,23 +266,10 @@ class Events(commands.Cog):
             try:
                 traceback = await self.bot.mystbin.post(traceback, syntax='python')
             except mystbin.APIError as error:
-                log.warning('[ERRORS] Error while uploading error traceback to mystbin | Code: {error.status_code} | Message: {error.message}')
+                log.warning(f'[ERRORS] Error while uploading error traceback to mystbin | Code: {error.status_code} | Message: {error.message}')
                 print(f'[ERRORS] Error while uploading error traceback to mystbin | Code: {error.status_code} | Message: {error.message}')
 
-        await self.bot.errors_webhook.send(content=f'{traceback}', username=f'{ctx.author}',
-                                           avatar_url=str(ctx.author.avatar_url_as(format='gif' if ctx.author.is_avatar_animated() else 'png')))
-
-    @commands.Cog.listener()
-    async def on_command(self, ctx: commands.Context) -> None:
-        log.info(f'[COMMANDS] Command used. Name: {ctx.command} | Invoker: {ctx.author} | Channel: {ctx.channel} ({ctx.channel.id}) | '
-                 f'{f"Guild: {ctx.guild} ({ctx.guild.id})" if ctx.guild else ""}')
-
-    @commands.Cog.listener()
-    async def on_socket_response(self, message: dict) -> None:
-
-        event = message.get('t', 'None')
-        if event is not None:
-            self.bot.socket_stats[event] += 1
+        await self.bot.errors_webhook.send(content=f'{traceback}', username=f'{ctx.author}', avatar_url=avatar_url)
 
 
 def setup(bot):

--- a/Life/cogs/information.py
+++ b/Life/cogs/information.py
@@ -327,7 +327,7 @@ class Information(commands.Cog):
         return await ctx.paginate_embed(entries=entries, per_page=30, title='List of channels, categories and voice channels.')
 
     @commands.command(name='avatar', aliases=['avy'])
-    async def avatar(self, ctx: context.Context, *, user: typing.Union[discord.Member, converters.UserConverter] = None):
+    async def avatar(self, ctx: context.Context, *, user: converters.UserConverter = None):
         """
         Display a user's avatar.
 

--- a/Life/utilities/context.py
+++ b/Life/utilities/context.py
@@ -58,3 +58,13 @@ class Context(commands.Context):
         paginator = paginators.EmbedsPaginator(ctx=self, **kwargs)
         await paginator.paginate()
         return paginator
+
+    async def try_dm(self, **kwargs) -> typing.Optional[discord.Message]:
+
+        try:
+            return await self.author.send(**kwargs)
+        except discord.Forbidden:
+            try:
+                return await self.channel.send(**kwargs)
+            except discord.Forbidden:
+                return

--- a/Life/utilities/converters.py
+++ b/Life/utilities/converters.py
@@ -37,7 +37,7 @@ class UserConverter(commands.UserConverter):
             try:
                 user = await ctx.bot.fetch_user(argument)
             except (discord.NotFound, discord.HTTPException):
-                raise commands.BadArgument
+                raise commands.UserNotFound(argument=argument)
 
         return user
 

--- a/Life/utilities/utils.py
+++ b/Life/utilities/utils.py
@@ -25,47 +25,47 @@ class Utils:
         self.bot = bot
 
         self.channel_emojis = {
-            'text': '<:text:739399497200697465>',
-            'text_locked': '<:text_locked:739399496953364511>',
-            'text_nsfw': '<:text_nsfw:739399497251160115>',
-            'news': '<:news:739399496936718337>',
-            'news_locked': '<:news_locked:739399497062416435>',
-            'voice': '<:voice:739399497221931058>',
+            'text':         '<:text:739399497200697465>',
+            'text_locked':  '<:text_locked:739399496953364511>',
+            'text_nsfw':    '<:text_nsfw:739399497251160115>',
+            'news':         '<:news:739399496936718337>',
+            'news_locked':  '<:news_locked:739399497062416435>',
+            'voice':        '<:voice:739399497221931058>',
             'voice_locked': '<:voice_locked:739399496924135476>',
-            'category': '<:category:738960756233601097>'
+            'category':     '<:category:738960756233601097>'
         }
 
         self.badge_emojis = {
-            'staff': '<:staff:738961032109752441>',
-            'partner': '<:partner:738961058613559398>',
-            'hypesquad': '<:hypesquad:738960840375664691>',
-            'bug_hunter': '<:bug_hunter:738961014275571723>',
-            'bug_hunter_level_2': '<:bug_hunter_level_2:739390267949580290>',
-            'hypesquad_bravery': '<:hypesquad_bravery:738960831596855448>',
-            'hypesquad_brilliance': '<:hypesquad_brilliance:738960824327995483>',
-            'hypesquad_balance': '<:hypesquad_balance:738960813460684871>',
-            'early_supporter': '<:early_supporter:738961113219203102>',
-            'system': '<:system_1:738960703284576378><:system_2:738960703288770650>',
-            'verified_bot': '<:verified_bot_1:738960728022581258><:verified_bot_2:738960728102273084>',
+            'staff':                  '<:staff:738961032109752441>',
+            'partner':                '<:partner:738961058613559398>',
+            'hypesquad':              '<:hypesquad:738960840375664691>',
+            'bug_hunter':             '<:bug_hunter:738961014275571723>',
+            'bug_hunter_level_2':     '<:bug_hunter_level_2:739390267949580290>',
+            'hypesquad_bravery':      '<:hypesquad_bravery:738960831596855448>',
+            'hypesquad_brilliance':   '<:hypesquad_brilliance:738960824327995483>',
+            'hypesquad_balance':      '<:hypesquad_balance:738960813460684871>',
+            'early_supporter':        '<:early_supporter:738961113219203102>',
+            'system':                 '<:system_1:738960703284576378><:system_2:738960703288770650>',
+            'verified_bot':           '<:verified_bot_1:738960728022581258><:verified_bot_2:738960728102273084>',
             'verified_bot_developer': '<:verified_bot_developer:738961212250914897>',
         }
 
         self.features = {
-            'VERIFIED': 'Is verified server',
-            'PARTNERED': 'Is partnered server',
-            'MORE_EMOJI': 'Can have 50+ emoji',
-            'DISCOVERABLE': 'Is discoverable',
-            'FEATURABLE': 'Is featurable',
-            'PUBLIC': 'Is public',
-            'VIP_REGIONS': 'Can have VIP voice regions',
-            'VANITY_URL': 'Can have vanity invite',
-            'INVITE_SPLASH': 'Can have invite splash',
-            'COMMERCE': 'Can have store channels',
-            'NEWS': 'Can have news channels',
-            'BANNER': 'Can have banner',
-            'ANIMATED_ICON': 'Can have animated icon',
-            'PUBLIC_DISABLED': 'Can not be public',
-            'WELCOME_SCREEN_ENABLED': 'Can have welcome screen',
+            'VERIFIED':                         'Is verified server',
+            'PARTNERED':                        'Is partnered server',
+            'MORE_EMOJI':                       'Can have 50+ emoji',
+            'DISCOVERABLE':                     'Is discoverable',
+            'FEATURABLE':                       'Is featurable',
+            'PUBLIC':                           'Is public',
+            'VIP_REGIONS':                      'Can have VIP voice regions',
+            'VANITY_URL':                       'Can have vanity invite',
+            'INVITE_SPLASH':                    'Can have invite splash',
+            'COMMERCE':                         'Can have store channels',
+            'NEWS':                             'Can have news channels',
+            'BANNER':                           'Can have banner',
+            'ANIMATED_ICON':                    'Can have animated icon',
+            'PUBLIC_DISABLED':                  'Can not be public',
+            'WELCOME_SCREEN_ENABLED':           'Can have welcome screen',
             'MEMBER_VERIFICATION_GATE_ENABLED': 'Has member verify gate'
         }
 
@@ -75,26 +75,26 @@ class Utils:
         }
 
         self.colours = {
-            discord.Status.online: 0x008000,
-            discord.Status.idle: 0xFF8000,
-            discord.Status.dnd: 0xFF0000,
-            discord.Status.offline: 0x808080,
+            discord.Status.online:    0x008000,
+            discord.Status.idle:      0xFF8000,
+            discord.Status.dnd:       0xFF0000,
+            discord.Status.offline:   0x808080,
             discord.Status.invisible: 0x808080,
         }
 
         self.verification_levels = {
-            discord.VerificationLevel.none: 'None - No criteria set.',
-            discord.VerificationLevel.low: 'Low - Must have a verified email.',
-            discord.VerificationLevel.medium: 'Medium - Must have a verified email and be registered on discord for more than 5 minutes.',
-            discord.VerificationLevel.high: 'High - Must have a verified email, be registered on discord for more than 5 minutes and be a member of the guild for more '
-                                            'then 10 minutes.',
-            discord.VerificationLevel.extreme: 'Extreme - Must have a verified email, be registered on discord for more than 5 minutes, be a member of the guild for '
-                                               'more then 10 minutes and a have a verified phone number.'
+            discord.VerificationLevel.none:    'None - No criteria set.',
+            discord.VerificationLevel.low:     'Low - Must have a verified email.',
+            discord.VerificationLevel.medium:  'Medium - Must have a verified email and be registered on discord for more than 5 minutes.',
+            discord.VerificationLevel.high:    'High - Must have a verified email, be registered on discord for more than 5 minutes and be a member of the guild for more then 10 '
+                                               'minutes.',
+            discord.VerificationLevel.extreme: 'Extreme - Must have a verified email, be registered on discord for more than 5 minutes, be a member of the guild for more then 10 '
+                                               'minutes and a have a verified phone number.'
         }
 
         self.content_filter_levels = {
-            discord.ContentFilter.disabled: 'None',
-            discord.ContentFilter.no_role: 'No roles',
+            discord.ContentFilter.disabled:    'None',
+            discord.ContentFilter.no_role:     'No roles',
             discord.ContentFilter.all_members: 'All members',
         }
 
@@ -119,9 +119,8 @@ class Utils:
         return datetime
 
     def format_datetime(self, *, datetime: typing.Union[pendulum.datetime, dt.datetime], seconds: bool = False) -> str:
-
         datetime = self.convert_datetime(datetime=datetime)
-        return datetime.format(f'dddd Do [of] MMMM YYYY [at] HH:mm{":ss" if seconds else ""} A (zz{"ZZ" if datetime.timezone == "UTC" else ""})')
+        return datetime.format(f'dddd Do [of] MMMM YYYY [at] HH:mm{":ss" if seconds else ""} A (zz{"ZZ" if datetime.timezone != "UTC" else ""})')
 
     def format_difference(self, *, datetime: typing.Union[pendulum.datetime, dt.datetime], suppress: typing.List[str] = None) -> str:
 


### PR DESCRIPTION
Fixes #11

- Moves all the BadArgument converters to use a mapping with the use of `getattr`.
- Generally cleans up some of the errors.
- Split traceback generation into its own function.